### PR TITLE
Quote $dotnetRoot argument to InstallDotNet invocation

### DIFF
--- a/eng/common/dotnet-install.sh
+++ b/eng/common/dotnet-install.sh
@@ -75,7 +75,7 @@ if [[ $architecture != "" ]] && [[ $architecture != $buildarch ]]; then
   dotnetRoot="$dotnetRoot/$architecture"
 fi
 
-InstallDotNet $dotnetRoot $version "$architecture" $runtime true $runtimeSourceFeed $runtimeSourceFeedKey || {
+InstallDotNet "$dotnetRoot" $version "$architecture" $runtime true $runtimeSourceFeed $runtimeSourceFeedKey || {
   local exit_code=$?
   Write-PipelineTelemetryError -Category 'InitializeToolset' -Message "dotnet-install.sh failed (exit code '$exit_code')." >&2
   ExitWithExitCode $exit_code


### PR DESCRIPTION
Failure to quote the argument leads to incorrect assignment of positional arguments if the working path contains spaces.

fixes #2435